### PR TITLE
Removed Ambiguity Errors in calling of RemoveItem() function

### DIFF
--- a/source/InterfaceKitEx/ColumnListView.cpp
+++ b/source/InterfaceKitEx/ColumnListView.cpp
@@ -453,7 +453,7 @@ BRow::BRow(float height)
 BRow::~BRow()
 {
 	while (true) {
-		BField* field = (BField*) fFields.RemoveItem(0L);
+		BField* field = (BField*) fFields.RemoveItem((long)0L);
 		if (field == 0)
 			break;
 
@@ -751,7 +751,7 @@ BColumnListView::BColumnListView(const char* name, uint32 flags,
 
 BColumnListView::~BColumnListView()
 {
-	while (BColumn* column = (BColumn*)fColumns.RemoveItem(0L))
+	while (BColumn* column = (BColumn*)fColumns.RemoveItem((long)0L))
 		delete column;
 }
 

--- a/source/InterfaceKitEx/ColumnListView.cpp
+++ b/source/InterfaceKitEx/ColumnListView.cpp
@@ -453,7 +453,7 @@ BRow::BRow(float height)
 BRow::~BRow()
 {
 	while (true) {
-		BField* field = (BField*) fFields.RemoveItem((long)0L);
+		BField* field = (BField*) fFields.RemoveItem(0l);
 		if (field == 0)
 			break;
 
@@ -751,7 +751,7 @@ BColumnListView::BColumnListView(const char* name, uint32 flags,
 
 BColumnListView::~BColumnListView()
 {
-	while (BColumn* column = (BColumn*)fColumns.RemoveItem((long)0L))
+	while (BColumn* column = (BColumn*)fColumns.RemoveItem(0l))
 		delete column;
 }
 


### PR DESCRIPTION
Making Torrentor by running "jam" was causing a plethora of errors, which I believe, were due to modified version of gcc.
Out of all the errors two were Error: call of overloaded 'RemoveItem(long int)' is ambiguous
(Attaching the screenshot below)
![errorList1](https://user-images.githubusercontent.com/75475819/163503751-216beb43-dc67-4577-9817-289671bba30a.PNG)

 Somehow, passing **0L** was not calling the proper function, but typecasting it to **long** did the work, and now the **Ambiguity Errors** are resolved
