### PR TITLE
Disabled type definition for Haiku, for definitions present both in supportDefs.h and local library

### DIFF
--- a/source/third_party/libutp/utypes.h
+++ b/source/third_party/libutp/utypes.h
@@ -15,8 +15,12 @@ typedef signed int int32;
 typedef unsigned __int64 uint64;
 typedef signed __int64 int64;
 #else
+
+#ifndef __HAIKU__
 typedef unsigned long long uint64;
 typedef long long int64;
+#endif
+
 #endif
 
 /* compile-time assert */


### PR DESCRIPTION
![errorList2](https://user-images.githubusercontent.com/75475819/163572765-33e278f7-b651-40b0-9b49-74a33b56fc92.PNG)

Resolved conflicting type-errors, which were happening because the type definitions were present both in Haiku's **supportDefs.h** and **utypes.h** (a local library)

The second definition is disabled for Haiku by a preprocessor check